### PR TITLE
Updated to work on big-sur with latest brew

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,9 +23,8 @@ EOT
 fi
 
 
-brew tap caskroom/cask
-brew install ag autojump bash-git-prompt cloc ctags ctop curl derailed/k9s/k9s dos2unix fasd git git-extras git-flow go helmfile hub htop httpie kubectl kubernetes-cli net-snmp nmap node nvm openssl pass rpm ssh-copy-id the_silver_searcher tig tiff2png tmux tree vim wget http://git.io/sshpass.rb
-brew cask install chicken cyberduck docker dropbox balenaetcher firefox google-chrome iterm2 java kindle skype slack spotify teamviewer vagrant visual-studio-code whatsapp opera virtualbox
+brew install ag autojump bash-git-prompt cloc ctags ctop curl derailed/k9s/k9s dos2unix fasd git git-extras git-flow go helmfile hub htop httpie kubectl kubernetes-cli net-snmp nmap node nvm openssl pass rpm ssh-copy-id the_silver_searcher tig tiff2png tmux tree vim wget 
+brew install chicken cyberduck docker dropbox balenaetcher firefox google-chrome iterm2 java kindle skype slack spotify teamviewer vagrant visual-studio-code whatsapp opera virtualbox
 
 # add completions for the above applications
 grep -qxF 'source <(kubectl completion bash)'  ~/.bash_profile


### PR DESCRIPTION
Removed sshpass to avoid
    `brew extract` or `brew create` and `brew tap-new` to create a formula file in a tap on GitHub instead.: Invalid usage: Non-checksummed download of sshpass formula file from an arbitrary URL is unsupported!  (UsageError)

don't need to install cask anymore, you just need homebrew
    https://stackoverflow.com/questions/58335410/error-caskroom-cask-was-moved-tap-homebrew-cask-cask-instead